### PR TITLE
Missing closing parenthesis in vue2 doc

### DIFF
--- a/docs/guide/started.md
+++ b/docs/guide/started.md
@@ -58,7 +58,7 @@ The [i18next documentation](https://www.i18next.com/) details all the translatio
 ```vue
 <template>
     <div class="container">
-     {{$t("greeter.hello-world" }}
+     {{$t("greeter.hello-world")}}
     </div>
 <template>
 


### PR DESCRIPTION
Fix a missing parenthesis in the getting started example for Vue.js v2

#### Checklist (for documentation change)

- [X] only relevant documentation part is changed (make a diff before you submit the PR)
- [X] motivation/reason is provided
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)