### PR TITLE
Custom slot name braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ const { t } = useTranslation();
 </script>
 ```
 
+#### Custom slot values
+
+Custom slot values may be useful when default braces ("{" and "}") are wrongly treated by the
+[Locise](https://github.com/locize/i18next-locize-backend) service or don't satisfy other needs.
+
 Use custom values for recognizing start and end of the insertion point of the `TranslationComponent`
 inside localization term:
 ```vue

--- a/README.md
+++ b/README.md
@@ -71,6 +71,71 @@ const term = computed(() => t("insurance"));
 </template>
 ```
 
+### Translation component
+
+```vue
+<i18n>
+{
+    "en": {
+        "message": "Open the {faq-link} page."
+        "faq": "FAQ"
+    },
+}
+</i18n>
+
+<template>
+  <TranslationComponent :translation="t('message')">
+    <template #faq-link>
+      <router-link :to="FAQ_ROUTE">
+        {{ t('faq') }}
+      </router-link>
+    </template>
+  </TranslationComponent>
+</template>
+
+<script setup>
+import { useTranslation, TranslationComponent } from "i18next-vue";
+const { t } = useTranslation();
+</script>
+```
+
+Use custom values for recognizing start and end of the insertion point of the `TranslationComponent`
+inside localization term:
+```vue
+// main.js
+app.use(I18NextVue, {
+    i18next,
+    slotStart: '<slot>',
+    slotEnd: '</slot>',
+});
+
+// component.vue
+
+<i18n>
+{
+    "en": {
+        "message": "Open the <slot>faq-link</slot> page."
+        "faq": "FAQ"
+    },
+}
+</i18n>
+
+<template>
+  <TranslationComponent :translation="t('message')">
+    <template #faq-link>
+      <router-link :to="FAQ_ROUTE">
+        {{ t('faq') }}
+      </router-link>
+    </template>
+  </TranslationComponent>
+</template>
+
+<script setup>
+import { useTranslation, TranslationComponent } from "i18next-vue";
+const { t } = useTranslation();
+</script>
+```
+
 ## Contributing
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ Custom slot values may be useful when default braces (`{` and `}`) are wrongly t
 
 Use custom values for recognizing start and end of the insertion point of the `TranslationComponent`
 inside localization term:
-```vue
+```js
 // main.js
 app.use(I18NextVue, {
     i18next,
     slotStart: '<slot>',
     slotEnd: '</slot>',
 });
-
+```
+```vue
 // component.vue
-
 <i18n>
 {
     "en": {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ const { t } = useTranslation();
 
 #### Custom slot values
 
-Custom slot values may be useful when default braces ("{" and "}") are wrongly treated by the
+Custom slot values may be useful when default braces (`{` and `}`) are wrongly treated by the
 [Locise](https://github.com/locize/i18next-locize-backend) service or don't satisfy other needs.
 
 Use custom values for recognizing start and end of the insertion point of the `TranslationComponent`

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const { t } = useTranslation();
 #### Custom slot values
 
 Custom slot values may be useful when default braces (`{` and `}`) are wrongly treated by the
-[Locise](https://github.com/locize/i18next-locize-backend) service or don't satisfy other needs.
+[Locize](https://github.com/locize/i18next-locize-backend) service or don't satisfy other needs.
 
 Use custom values for recognizing start and end of the insertion point of the `TranslationComponent`
 inside localization term:

--- a/README.md
+++ b/README.md
@@ -84,19 +84,14 @@ const term = computed(() => t("insurance"));
 </i18n>
 
 <template>
-  <TranslationComponent :translation="t('message')">
+  <TranslationComponent :translation="$t('message')">
     <template #faq-link>
       <router-link :to="FAQ_ROUTE">
-        {{ t('faq') }}
+        {{ $t('faq') }}
       </router-link>
     </template>
   </TranslationComponent>
 </template>
-
-<script setup>
-import { useTranslation, TranslationComponent } from "i18next-vue";
-const { t } = useTranslation();
-</script>
 ```
 
 #### Custom slot values
@@ -115,7 +110,7 @@ app.use(I18NextVue, {
 });
 ```
 ```vue
-// component.vue
+<!-- Component.vue -->
 <i18n>
 {
     "en": {
@@ -126,19 +121,14 @@ app.use(I18NextVue, {
 </i18n>
 
 <template>
-  <TranslationComponent :translation="t('message')">
+  <TranslationComponent :translation="$t('message')">
     <template #faq-link>
       <router-link :to="FAQ_ROUTE">
-        {{ t('faq') }}
+        {{ $t('faq') }}
       </router-link>
     </template>
   </TranslationComponent>
 </template>
-
-<script setup>
-import { useTranslation, TranslationComponent } from "i18next-vue";
-const { t } = useTranslation();
-</script>
 ```
 
 ## Contributing

--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,7 @@ interface VueI18NextOptions {
     rerenderOn?: ('languageChanged' | 'loaded' | 'added' | 'removed')[];
     // Optional custom pattern for matching slot start of the `TranslationComponent.
     slotStart?: string,
-    // Optional custom pattern for matching slot start of the `TranslationComponent.
+    // Optional custom pattern for matching slot end of the `TranslationComponent.
     slotEnd?: string,
 }
 

--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,8 @@ interface VueI18NextOptions {
     slotEnd?: string,
 }
 
+let slotPattern: RegExp;
+
 export default function install(app: App, {
     i18next,
     rerenderOn = ['languageChanged', 'loaded', 'added', 'removed'],
@@ -121,7 +123,8 @@ export default function install(app: App, {
             return Reflect.get(target, prop);
         }
     });
-    app.config.globalProperties.$i18nextSlotNamePattern = slotNamePattern(slotStart, slotEnd);
+
+    slotPattern = slotNamePattern(slotStart, slotEnd);
 
     /** Translation function respecting lng and ns. The namespace can be overriden in $t calls using a key prefix or the 'ns' option. */
     function getTranslationFunction(lng?: string, ns?: string[]): TFunction {
@@ -199,13 +202,12 @@ export const TranslationComponent = defineComponent({
     },
     setup(props, { slots }) {
         return () => {
-            const slotNamePattern = currentInstance().appContext.config.globalProperties.$i18nextSlotNamePattern;
             const translation = props.translation;
             const result = [];
 
             let match;
             let lastIndex = 0;
-            while ((match = slotNamePattern.exec(translation)) !== null) {
+            while ((match = slotPattern.exec(translation)) !== null) {
                 result.push(translation.substring(lastIndex, match.index))
                 const slot = slots[match[1]];
                 if (slot) {
@@ -213,7 +215,7 @@ export const TranslationComponent = defineComponent({
                 } else {
                     result.push(match[0]);
                 }
-                lastIndex = slotNamePattern.lastIndex;
+                lastIndex = slotPattern.lastIndex;
             }
             result.push(translation.substring(lastIndex))
             return result;


### PR DESCRIPTION
In this PR I introduce the possibility to provide custom start and end braces (or other string values) used to recognize the end and start of a slot of the `TranslationComponent`.

This may be useful when default braces (`{` and `}`) are wrongly treated by the [Locize](https://github.com/locize/i18next-locize-backend) service or don't satisfy other needs. In our case, the Locize treated single braces as "wrong" double braces, so we couldn't sync our localization terms with the Locize service without additional refactoring. This service is needed for our translators to edit localization terms and see how it looks in real time. We have to do double refactoring each time before sync. To avoid it, I propose a little change in this repo.
 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [ ] tests are included (tested the build of the final commit in real project by replacing the library file)
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [X] only relevant documentation part is changed (make a diff before you submit the PR)
- [X] motivation/reason is provided
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)