### PR TITLE
Fix typescript module augmentation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { ref, getCurrentInstance, App, defineComponent, VNode, nextTick } from "vue";
 import { i18n, TFunction, Namespace, KeyPrefix } from "i18next";
 
-declare module "@vue/runtime-core" {
+declare module "vue" {
 	interface ComponentCustomProperties {
 		$t: TFunction;
 		$i18next: i18n;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"scripts": {
 		"dev": "npm run build -- --watch index.ts",
 		"build": "tsup index.ts --format esm --dts",
+                "prepare": "npm run build",
 		"test": "vitest",
 		"test-ci": "vitest run",
 		"coverage": "vitest run --coverage && rm -rf ./coverage",


### PR DESCRIPTION
This PR fixes a type declaration issue with vue.

The package augments the ComponentCustomProperties type to include declarations for $t and $i18next. The current release does this by augmenting the module @vue/runtime-core

This conflicts with augmentation for the module "vue" - only one of the augmented modules will be effective, and the recommended module is "vue". Other packages have made that transition (e.g. vue-router), leading to typescript issues.

To allow this package to be included as a git dependency in a project, a "prepare" task has been added to package.json. While not strictly related to the issue with module augmentations, this allows us to use the updated module from our fork without having to publish a package.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [ ] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [] only relevant documentation part is changed (make a diff before you submit the PR)
- [] motivation/reason is provided
- [] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)