### PR TITLE
perf: switch to shallowRef

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { ref, defineComponent, nextTick, inject, type App, type VNode } from "vue";
+import { shallowRef, defineComponent, nextTick, inject, type App, type VNode } from "vue";
 import { i18n, type TFunction, type Namespace, type KeyPrefix } from "i18next";
 
 declare module "vue" {
@@ -29,7 +29,7 @@ export default function install(
 ): void {
 	// the ref (internally) tracks which Vue instances use translations
 	// Vue will automatically trigger re-renders when the value of 'lastI18nChange' changes
-	const lastI18nChange = ref(new Date());
+	const lastI18nChange = shallowRef(new Date());
 	const invalidate = () =>
 		nextTick(() => {
 			// defer, so namespace loading is actually complete before re-rendering


### PR DESCRIPTION
Given the value of this ref is accessed shallowly and we just want `.value` to be reactive, it makes more sense to use [shallowRef](https://vuejs.org/api/reactivity-advanced.html#shallowref), which is also specifically aimed to integrate with external state management systems (exactly our use case here).

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)